### PR TITLE
Feature/cors

### DIFF
--- a/plugin/access.lua
+++ b/plugin/access.lua
@@ -14,7 +14,6 @@ local function error_response(status, code, message, config)
 
     if config.cors_origin then
         ngx.header['Access-Control-Allow-Origin'] = config.cors_origin
-        ngx.header['Access-Control-Allow-Credentials'] = 'true'
     end
     
     ngx.say(jsonData)

--- a/plugin/access.lua
+++ b/plugin/access.lua
@@ -14,6 +14,7 @@ local function error_response(status, code, message, config)
 
     if config.cors_origin then
         ngx.header['Access-Control-Allow-Origin'] = config.cors_origin
+        ngx.header['Access-Control-Allow-Credentials'] = 'true'
     end
     
     ngx.say(jsonData)

--- a/plugin/phantom-token-1.0.0-2.rockspec
+++ b/plugin/phantom-token-1.0.0-2.rockspec
@@ -1,5 +1,5 @@
 package = "phantom-token"
-version = "1.0.0-1"
+version = "1.0.0-2"
 source = {
   url = "."
 }

--- a/plugin/schema.lua
+++ b/plugin/schema.lua
@@ -9,7 +9,8 @@ return {
                 { client_secret = { type = "string", required = true } },
                 { token_cache_seconds = { type = "number", required = true, default = 0 } },
                 { scope = { type = "string", required = false } },
-                { verify_ssl = { type = "boolean", required = true, default = true } }
+                { verify_ssl = { type = "boolean", required = true, default = true } },
+                { cors_origin = { type = "string", required = false } }
             }
         }}
     }

--- a/plugin/schema.lua
+++ b/plugin/schema.lua
@@ -10,7 +10,7 @@ return {
                 { token_cache_seconds = { type = "number", required = true, default = 0 } },
                 { scope = { type = "string", required = false } },
                 { verify_ssl = { type = "boolean", required = true, default = true } },
-                { cors_origin = { type = "string", required = false } }
+                { trusted_web_origins = { type = "array", required = false, default = {}, elements = { type = "string" } } },
             }
         }}
     }

--- a/plugin/schema.lua
+++ b/plugin/schema.lua
@@ -10,7 +10,7 @@ return {
                 { token_cache_seconds = { type = "number", required = true, default = 0 } },
                 { scope = { type = "string", required = false } },
                 { verify_ssl = { type = "boolean", required = true, default = true } },
-                { cors_origin = { type = "string", required = false } }
+                { cors_origin = { type = "string", required = false, default = "" } }
             }
         }}
     }

--- a/plugin/schema.lua
+++ b/plugin/schema.lua
@@ -10,7 +10,7 @@ return {
                 { token_cache_seconds = { type = "number", required = true, default = 0 } },
                 { scope = { type = "string", required = false } },
                 { verify_ssl = { type = "boolean", required = true, default = true } },
-                { cors_origin = { type = "string", required = false, default = "" } }
+                { cors_origin = { type = "string", required = false } }
             }
         }}
     }


### PR DESCRIPTION
Added a CORS parameter so that an SPA can read error responses from the plugin. This required a new config parameter for the web origin. It is backwards compatible and I have updated the version to 1.0.2. Is there anything Jonas would like to do in relation to the version published on the Kong website? 

In my testing I found that [Access-Control-Allow-Credentials](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) is needed in order for JS to read the response for a CORS credentials request and the Mozilla page says this also.

Feel free to tweak when I am away if needed, but it will be good to get this merged as part of the BFF release 1. Please update the [deploy.sh script](https://github.com/curityio/web-oauth-via-bff/blob/dev/deployment/deploy.sh#L41) when complete, to remove the commented lines that change branch.