### PR TITLE
Fix scope verification order to reduce unnecessary server load

### DIFF
--- a/plugin/access.lua
+++ b/plugin/access.lua
@@ -193,6 +193,13 @@ local function verify_access_token(access_token, config)
     local result = introspect_access_token(access_token, config)
     if result.status == 200 then
 
+        -- Verify the scope after caching the introspection results
+        -- This ensures that an invalid token doesn't cause repeated introspection requests
+        -- This reduces potential load on the authorization server
+        if not verify_scope(result.jwt, config.scope) then
+            return { status = 403 }
+        end
+
         local time_to_live = config.token_cache_seconds
         if result.expiry > 0 and result.expiry < config.token_cache_seconds then
             time_to_live = result.expiry
@@ -204,13 +211,6 @@ local function verify_access_token(access_token, config)
         -- The expiry value is a number of seconds from the current time
         -- https://github.com/openresty/lua-nginx-module#ngxshareddictset
         dict:set(access_token, result.jwt, time_to_live)
-
-        -- Verify the scope after caching the introspection results
-        -- This ensures that an invalid token doesn't cause repeated introspection requests
-        -- This reduces potential load on the authorization server
-        if not verify_scope(result.jwt, config.scope) then
-            return { status = 403 }
-        end
     end
 
     return result


### PR DESCRIPTION
The verify_access_token function doesn't effectively prevent load on the authorization server if the scope is invalid, as suggested by the comment. The primary issue in the logic lies in the order of operations, particularly in how the result of the token introspection is handled and when the scope verification occurs.

## Analysis of the Code Flow

1. Token Introspection and Caching:
* The function first checks if the introspection result for a given access token is already cached. If it is, it returns the cached JWT without further introspection, which is efficient.
* If not cached, it proceeds to introspect the token and then caches the introspection result if the status is 200 (OK).

2. Scope Verification:
* The scope verification (verify_scope(result.jwt, config.scope)) only occurs after the JWT has been cached. This means that even if the scope verification fails (resulting in a 403 status), the JWT has already been stored in the cache.
* This sequence could lead to unnecessary caching of JWTs that are not valid for the requested scope. If a JWT with an invalid scope is cached, subsequent requests with the same token would not trigger introspection or scope verification until the cache entry expires, potentially allowing repeated access attempts with an inappropriate scope.

## Implications
* Increased Load on Authorization Server: Since the token's JWT is cached before verifying if it meets the scope requirements, the server might end up caching tokens that don't actually have the required scope. This can lead to situations where the scope needs to be checked again after the cache expires, thereby not reducing the load on the authorization server as intended.

